### PR TITLE
Fix issue with go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Note: This application now uses a local server to handle the OAuth2 flow, which 
 Install sendgmailapi:
 
 ```
-go get github.com/paralin/sendgmailapi@latest
+go install github.com/paralin/sendgmailapi@latest
 ```
 
 Run the setup to get the token:
 
 ```
-sendgmailapi -setup
+$(go env GOPATH)/bin/sendgmailapi -setup
 ```
 
 This will open a browser window for you to authorize the application and generate the token.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sendgmailapi
+module github.com/paralin/sendgmailapi
 
 go 1.22.5
 


### PR DESCRIPTION
The command `go install` is supposed to be used instead of `go get` for module installation, see [here](https://go.dev/doc/go-get-install-deprecation).
The install command had an issue with the module name:
```
go: github.com/paralin/sendgmailapi@latest: version constraints conflict:
	github.com/paralin/sendgmailapi@v1.0.0: parsing go.mod:
	module declares its path as: sendgmailapi
	        but was required as: github.com/paralin/sendgmailapi
```
This commit is fixing the module name issue and updates the `README.md` to use `go install`.